### PR TITLE
Return previous damage type after death

### DIFF
--- a/lua/zbase/npc_base_internal.lua
+++ b/lua/zbase/npc_base_internal.lua
@@ -3597,7 +3597,8 @@ function NPC:OnEntityTakeDamage( dmg )
 
     -- Prevent engine gib
     if goingToDie && ShouldPreventGib[self:GetClass()] then
-
+self.ZBasePreDeathDamageType = dmg:GetDamageType()
+		
         if dmg:IsDamageType(DMG_DISSOLVE) or (IsValid(infl) && infl:GetClass()=="prop_combine_ball") then
             dmg:SetDamageType(bit.bor(DMG_DISSOLVE, DMG_NEVERGIB))
         else
@@ -3684,6 +3685,10 @@ function NPC:OnDeath( attacker, infl, dmg, hit_gr )
     if self.Dead then return end
     self.Dead = true
 
+    -- Return previous damage
+if self.ZBasePreDeathDamageType then
+dmg:SetDamageType(self.ZBasePreDeathDamageType)
+end
 
     -- Stop sounds
     self.IsSpeaking = false


### PR DESCRIPTION
This workaround was made to fix gibbing from some of my addons.