### PR TITLE
Replace CONV_AddSpawnFlags with AddSpawnFlags for manhack

### DIFF
--- a/lua/zbase/npc_patches/npc_manhack.lua
+++ b/lua/zbase/npc_patches/npc_manhack.lua
@@ -4,6 +4,6 @@ local SF_MANHACK_USE_AIR_NODES  = 262144
 ZBasePatchTable[my_cls] = function( NPC )
     -- Manhacks use air nodes
     function NPC:Patch_PreSpawn()
-        self:CONV_AddSpawnFlags(SF_MANHACK_USE_AIR_NODES)
+        self:AddSpawnFlags( SF_MANHACK_USE_AIR_NODES )
     end
 end


### PR DESCRIPTION
Updated the npc_manhack patch to use the standard AddSpawnFlags method instead of CONV_AddSpawnFlags when setting the SF_MANHACK_USE_AIR_NODES flag during pre-spawn. This improves consistency with other NPC spawn flag handling.