### PR TITLE
Replace CONV_HasCapability with CapabilitiesHas

### DIFF
--- a/lua/weapons/gmod_tool/stools/zbase_guard.lua
+++ b/lua/weapons/gmod_tool/stools/zbase_guard.lua
@@ -39,7 +39,7 @@ if SERVER then
         -- DISABLE MOVEMENT
         elseif self.ZBase_Guard_HasMovementSet && bool == false then
             -- Regular ground NPC/SNPCs
-            if self:CONV_HasCapability(CAP_MOVE_GROUND) then
+            if self:CapabilitiesHas(CAP_MOVE_GROUND) then
                 self:CapabilitiesRemove(CAP_MOVE_GROUND)
                 self.ZBase_Guard_HadGroundMovement = true
             end

--- a/lua/zbase/controller/sv.lua
+++ b/lua/zbase/controller/sv.lua
@@ -94,7 +94,7 @@ function ZBASE_CONTROLLER:StartControlling( ply, npc )
 
     -- Disable jump capability for NPC
     -- Jumping will be controlled manually by the player
-    npc.ZBASE_HadJumpCap = npc:CONV_HasCapability(CAP_MOVE_JUMP)
+    npc.ZBASE_HadJumpCap = npc:CapabilitiesHas(CAP_MOVE_JUMP)
     npc:CapabilitiesRemove(CAP_MOVE_JUMP)
 
     -- NPC hooks/vars
@@ -304,7 +304,7 @@ function NPC:ZBASE_Controller_InitAttacks()
         -- Also add a CustomControllerInitAttacks so that developers can add their own
 
         -- If ZBase NPC can use weapons
-        if self:CONV_HasCapability(CAP_USE_WEAPONS) then
+        if self:CapabilitiesHas(CAP_USE_WEAPONS) then
             -- Weapon attack
             self:ZBASE_ControllerAddAttack(
                 function()
@@ -629,7 +629,7 @@ function NPC:ZBASE_ControllerThink()
             local destDist = self:OBBMaxs().x+200
             local moveVec = moveDir*destDist
 
-            if self:IsOnGround() or self:CONV_HasCapability(CAP_MOVE_FLY) or self:GetNavType()==NAV_FLY then
+            if self:IsOnGround() or self:CapabilitiesHas(CAP_MOVE_FLY) or self:GetNavType()==NAV_FLY then
                 if ply:KeyDown(IN_JUMP) && self:SelectWeightedSequence(ACT_JUMP) != -1 && !self.ZBASE_Controller_JumpOnCooldown then
                     self:ZBASE_Controller_Jump(moveDir)
                 else
@@ -637,7 +637,7 @@ function NPC:ZBASE_ControllerThink()
                     self:ZBASE_Controller_Move(self:WorldSpaceCenter()+moveVec)
                 end
             end
-        elseif self:CONV_HasCapability(CAP_MOVE_GROUND) then
+        elseif self:CapabilitiesHas(CAP_MOVE_GROUND) then
             -- Be still when should not move
             -- Stopped moving so remove ground capabilities and clear goal etc
             self:CapabilitiesRemove(CAP_MOVE_GROUND)

--- a/lua/zbase/npc_base/sv_internal.lua
+++ b/lua/zbase/npc_base/sv_internal.lua
@@ -514,7 +514,7 @@ function NPC:ZBaseThink()
         end
 
         -- Foot steps
-        if self.NextFootStepTimer < CurTime() && self:GetNavType()==NAV_GROUND && self:CONV_HasCapability(CAP_MOVE_GROUND) then
+        if self.NextFootStepTimer < CurTime() && self:GetNavType()==NAV_GROUND && self:CapabilitiesHas(CAP_MOVE_GROUND) then
             self:FootStepTimer()
         end
 
@@ -1722,7 +1722,7 @@ function NPC:AITick_Slow()
 
     -- Some prop doors normally won't open for NPCs
     -- Force open those doors
-    if self.ZBase_IsMoving && self:CONV_HasCapability(CAP_OPEN_DOORS) then
+    if self.ZBase_IsMoving && self:CapabilitiesHas(CAP_OPEN_DOORS) then
         local vel = self:GetMoveVelocity()
         local wspacecenter = self:WorldSpaceCenter()
         for _, ent in ipairs(ents.FindAlongRay(wspacecenter, wspacecenter+vel, vector_origin, vector_origin)) do


### PR DESCRIPTION
Refactored code to use the CapabilitiesHas method instead of CONV_HasCapability for checking NPC capabilities across zbase_guard, controller, and npc_base modules. This improves consistency and likely aligns with updated API or naming conventions.

This pull request refactors several NPC capability checks throughout the codebase to use the `CapabilitiesHas` method instead of the older `CONV_HasCapability`. This change improves consistency and likely aligns with updated conventions or APIs for checking NPC capabilities.

Refactoring capability checks:

* Replaced all calls to `CONV_HasCapability` with `CapabilitiesHas` in key NPC logic, including movement, jumping, weapon use, ground movement, footstep timing, and door opening checks. [[1]](diffhunk://#diff-506a3f6f6034e156c843caf6ac83ad1e7301189b10fa5bcf1baab97d7d563a69L42-R42) [[2]](diffhunk://#diff-db67a73d6d1edcab6d28f2afb25ea232c3529c5e3d6fb39661951a5cb9c109cbL97-R97) [[3]](diffhunk://#diff-db67a73d6d1edcab6d28f2afb25ea232c3529c5e3d6fb39661951a5cb9c109cbL307-R307) [[4]](diffhunk://#diff-db67a73d6d1edcab6d28f2afb25ea232c3529c5e3d6fb39661951a5cb9c109cbL632-R640) [[5]](diffhunk://#diff-d288bd46766fb2687263351a783407c80d5e01bf9c397bd66f9c926448e88d07L517-R517) [[6]](diffhunk://#diff-d288bd46766fb2687263351a783407c80d5e01bf9c397bd66f9c926448e88d07L1725-R1725)